### PR TITLE
Update related projects in the ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,12 @@
 *Simple sandbox game, built with .NET and Windows Forms.*
 ![436360070-c231e245-2357-4531-a7fd-80d8d7d2b3c0](https://github.com/user-attachments/assets/4b854d4c-5b03-4ea3-abfa-533d8206b9f0)
 
-Related projects:
-
-- [PWSandboxConsole](https://github.com/PWSandbox/PWSandboxConsole): **PWSandboxConsole** is a cross-platform console version of PWSandbox.
-- [Mono PWSandbox](https://github.com/yarb00/Mono_PWSandbox): **Mono PWSandbox** is a fork of PWSandbox, focused on compatibility with the .NET Framework and Mono.
+> [!NOTE]
+> PWSandbox is a **Windows-only** app!
+> If you're not on Windows, check out [PWSandboxConsole](https://github.com/PWSandbox/PWSandboxConsole): a cross-platform console version of PWSandbox.
+> 
+> > [!WARNING]
+> > PWSandboxConsole is still in the early stages of development. Expect a lot of bugs.
+> > 
+> > [!IMPORTANT]
+> > There are no compiled assemblies of PWSandboxConsole. You will have to compile it yourself.


### PR DESCRIPTION
- Remove Mono PWSandbox from the ReadMe since it's no longer supported.
- Add more details about PWSandboxConsole.